### PR TITLE
🐛 Stop pushing null in end

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,10 +90,6 @@ class PromiseReporter extends Readable {
 
   end () {
     this._allQueued = true
-
-    if (this._pending.length === 0) {
-      this.push(null)
-    }
   }
 }
 


### PR DESCRIPTION
This fixes the issue of end prematurely ending the stream and
causeing a "stream.push() after EOF" error.
